### PR TITLE
Updating README.md to fix the DatePicker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ const ExampleApp = (): JSX.Element => {
     <View>
       <DatePicker
         value={pickedDate}
-        onDateChange={handleDateChange}
+        onDateChange={setPickedDate}
         title="Date Picker"
         text={handleText()}
         isNullable={false}


### PR DESCRIPTION
Using the `setPickedDate` in the `onDateChange` prop. Now the date picker example in the README will work.

I noticed that after copy pasting the example code the date value was not persisting in the state because a custom function `handleDateChange` was being loaded in the `onDateChange` prop that was not declared in the example.